### PR TITLE
fix: pattern to rule /api/*

### DIFF
--- a/fastpath.go
+++ b/fastpath.go
@@ -102,7 +102,7 @@ func (p *Path) Match(s string) ([]string, bool) {
 			if partLen < i || (i == 0 && partLen > 0) || s[:i] != segment.Const {
 				return nil, false
 				// is not last part, it is bigger than the const part but has no slash at the end
-			} else if false == segment.IsLast && partLen > i && s[i] != '/' {
+			} else if partLen > i && s[i] != '/' {
 				return nil, false
 			}
 		}

--- a/fastpath.go
+++ b/fastpath.go
@@ -99,10 +99,7 @@ func (p *Path) Match(s string) ([]string, bool) {
 		} else {
 			// check const segment
 			i = len(segment.Const)
-			if partLen < i || (i == 0 && partLen > 0) || s[:i] != segment.Const {
-				return nil, false
-				// it is bigger than the const part but has no slash at the end
-			} else if partLen > i && s[i] != '/' {
+			if partLen < i || (i == 0 && partLen > 0) || s[:i] != segment.Const || (partLen > i && s[i] != '/') {
 				return nil, false
 			}
 		}

--- a/fastpath.go
+++ b/fastpath.go
@@ -101,7 +101,7 @@ func (p *Path) Match(s string) ([]string, bool) {
 			i = len(segment.Const)
 			if partLen < i || (i == 0 && partLen > 0) || s[:i] != segment.Const {
 				return nil, false
-				// is not last part, it is bigger than the const part but has no slash at the end
+				// it is bigger than the const part but has no slash at the end
 			} else if partLen > i && s[i] != '/' {
 				return nil, false
 			}

--- a/fastpath.go
+++ b/fastpath.go
@@ -101,6 +101,9 @@ func (p *Path) Match(s string) ([]string, bool) {
 			i = len(segment.Const)
 			if partLen < i || (i == 0 && partLen > 0) || s[:i] != segment.Const {
 				return nil, false
+				// is not last part, it is bigger than the const part but has no slash at the end
+			} else if false == segment.IsLast && partLen > i && s[i] != '/' {
+				return nil, false
 			}
 		}
 

--- a/fastpath_test.go
+++ b/fastpath_test.go
@@ -68,6 +68,7 @@ func Test_With_With_Param(t *testing.T) {
 		},
 	)
 }
+
 func Test_With_Without_A_Param_Or_Wildcard(t *testing.T) {
 	checkCases(
 		t,
@@ -113,6 +114,9 @@ func Test_With_With_Simple_Wildcard(t *testing.T) {
 			{uri: "/api/", params: []string{""}, ok: true},
 			{uri: "/api/joker", params: []string{"joker"}, ok: true},
 			{uri: "/api", params: []string{""}, ok: true},
+			{uri: "/api/v1/entity", params: []string{"v1/entity"}, ok: true},
+			{uri: "/api2/v1/entity", params: nil, ok: false},
+			{uri: "/api_ignore/v1/entity", params: nil, ok: false},
 		},
 	)
 }


### PR DESCRIPTION
Fixed rule on code to be respected when to have a wildcard in the last parameter.
It shouldn't match `/api2/v1/entity`